### PR TITLE
Log out request should be POST

### DIFF
--- a/app/scripts/services/djangoAuth.js
+++ b/app/scripts/services/djangoAuth.js
@@ -96,7 +96,7 @@ angular.module('angularDjangoRegistrationAuthApp')
         'logout': function(){
             var djangoAuth = this;
             return this.request({
-                'method': "GET",
+                'method': "POST",
                 'url': "/logout/"
             }).then(function(data){
                 delete $http.defaults.headers.common.Authorization;


### PR DESCRIPTION
As indicated in the [documentation](http://django-rest-auth.readthedocs.org/en/latest/api_endpoints.html), the logout API endpoint only works when accessed via POST request.
